### PR TITLE
remove cast

### DIFF
--- a/src/main/kotlin/dashfwd/Part2_2_UsingACache.kt
+++ b/src/main/kotlin/dashfwd/Part2_2_UsingACache.kt
@@ -1,18 +1,16 @@
 package dashfwd
 
-import org.cache2k.Cache
 import org.cache2k.Cache2kBuilder
 
 /**
  * see https://cache2k.org/docs/latest/user-guide.html#using-a-cache
  */
 class Part2_2_UsingACache {
-    val cache = object : Cache2kBuilder<String, String>() {}
+    private val cache = object : Cache2kBuilder<String, String>() {}
         .name("routeToAirline")
         .eternal(true) // alternately expireAfterWrite(2, TimeUnit.MINUTES)
         .entryCapacity(100)
         .build()
-            as Cache<String, String>
 
     fun execute() {
         // populate with our favorites


### PR DESCRIPTION
Actually the cache2k API was designed as such, that the resulting cache type can be inferred from the builder creating.

I can see that some compiler warnings pop in some variants, complaining about null.
I will see whether this can improved in the next releases, so this is more smooth. See:
https://github.com/cache2k/cache2k/issues/125

This PR removes the cast, as an example in one file. I would prefer that the cache2k API usage has no cast here. to be more clean and crispy.

That PR is more like a note, that I am looking into the issue. Feel free to reject it.